### PR TITLE
Fix an issue with default docker-compose.override.yml

### DIFF
--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -11,7 +11,7 @@ services:
                 DUMP_ENV: 1
         volumes:
             - .:/app
-        environment:
+#        environment:
             # Docker for mac : try remote_host=host.docker.internal instead of remote_connect_back
 #            XDEBUG_CONFIG: >-
 #                remote_enable=1
@@ -22,7 +22,7 @@ services:
         volumes:
             - .:/app
         ports:
-            - 127.0.0.1:8000:80
+            - 80:80
     apache-test:
         build:
             context: .

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -22,7 +22,7 @@ services:
         volumes:
             - .:/app
         ports:
-            - 80:80
+            - 8000:80
     apache-test:
         build:
             context: .


### PR DESCRIPTION
I commented the ```environment:```because if the environment section is empty (not on mac), it causes an issue when compiling the docker container.

I also removed the limitation of localhost to the Apache container so you can test your website on multiple devices (also required if the dev server is not your PC)